### PR TITLE
Handling of asset_name and sequence_number instead of telescope name; ignore elements without corsika spheres

### DIFF
--- a/layout_array.py
+++ b/layout_array.py
@@ -42,7 +42,10 @@ class ArrayData:
         """
 
         tel = layout_telescope.TelescopeData()
-        tel.name = row["telescope_name"]
+        if "telescope_name" in table.colnames:
+            tel.name = row["telescope_name"]
+        if "asset_code" in table.colnames and "sequence_number" in table.colnames:
+            tel.name = row["asset_code"] + "-" + row["sequence_number"]
         if "geo_code" in table.colnames:
             tel.geo_code = row["geo_code"]
         if "pos_x" in table.colnames:
@@ -79,11 +82,13 @@ class ArrayData:
             return False
 
         # require telescope_name in telescope lists
-        if "telescope_name" not in table.colnames:
+        if ("telescope_name" not in table.colnames and
+            "asset_code" not in table.colnames and
+             "sequence_number" not in table.colnames):
             logging.error(
                 "Error reading telescope names from {}".format(telescope_file)
             )
-            logging.error("   required column telescope_name missing")
+            logging.error("   required column telescope_name or asset_code missing")
             logging.error(table.meta)
             return False
 

--- a/layout_telescope.py
+++ b/layout_telescope.py
@@ -188,7 +188,7 @@ class TelescopeData:
             return "MST"
         elif name[0:1] == "S":
             return "SST"
-        return None
+        return "CALIB"
 
     def convert_asl_to_corsika(self, corsika_obslevel, corsika_sphere_center):
         """
@@ -203,11 +203,7 @@ class TelescopeData:
             try:
                 self.z += corsika_sphere_center[self.get_telescope_type(self.name)]
             except KeyError:
-                logging.error(
-                    "Failed finding corsika sphere center for {} (to corsika)".format(
-                        self.get_telescope_type(self.name)
-                    )
-                )
+                pass
 
     def convert_corsika_to_asl(self, corsika_obslevel, corsika_sphere_center):
         """
@@ -219,11 +215,7 @@ class TelescopeData:
         try:
             self.alt -= corsika_sphere_center[self.get_telescope_type(self.name)]
         except KeyError:
-            logging.error(
-                "Failed finding corsika sphere center for {} (to asl)".format(
-                    self.get_telescope_type(self.name)
-                )
-            )
+            pass
 
     def convert(
         self,


### PR DESCRIPTION
1. Newer files for telescope positions include columns `asset_code` and `sequence_number` instead of `telescope_name`.
- build telescope name from both columns (e.g., from `LSTN` and `03` build `LSTN-03`
2. Newer files for array elements positions (telescopes + e.g. weather and calibration devices) include elements without corsika spheres defined. Ignore those elements and don't through an exception.